### PR TITLE
added keyboard shortcuts to open modal, discard and save

### DIFF
--- a/resources/views/bankAccounts.blade.php
+++ b/resources/views/bankAccounts.blade.php
@@ -26,7 +26,7 @@
     </script>
 
     <button type="button" id="btnOpenAddModal" class="btn btn-primary mb-4" data-bs-toggle="modal"
-        data-bs-target="#bankAccountModal">Konto erstellen</button>
+        data-bs-target="#bankAccountModal" accesskey="a">Konto erstellen</button>
 
     <div class="text-center">
         <p id="txtBalance" class="fw-bolder display-3 mb-0 {{ $balanceAllAccounts < 0 ? 'text-danger' : 'text-success' }}">
@@ -125,12 +125,12 @@
                     </div>
 
                     <div class="modal-footer">
-                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal">
+                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal" accesskey="d">
                             Verwerfen
                         </button>
 
                         <button class="btn btn-primary"
-                            type="submit">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
+                            type="submit" accesskey="s">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
                         </button>
                     </div>
                 </form>

--- a/resources/views/categories.blade.php
+++ b/resources/views/categories.blade.php
@@ -26,7 +26,7 @@
     </script>
 
     <button type="button" id="btnOpenAddModal" class="btn btn-primary mb-4" data-bs-toggle="modal"
-        data-bs-target="#categoryModal">Kategorie erstellen</button>
+        data-bs-target="#categoryModal" accesskey="a">Kategorie erstellen</button>
 
     <div id="alertDiv" class="alert d-none" role="alert">{{ session('status') }}</div>
 
@@ -103,12 +103,12 @@
                     </div>
 
                     <div class="modal-footer">
-                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal">
+                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal" accesskey="d">
                             Verwerfen
                         </button>
 
                         <button class="btn btn-primary"
-                            type="submit">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
+                            type="submit" accesskey="s">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
                         </button>
                     </div>
                 </form>

--- a/resources/views/expenses.blade.php
+++ b/resources/views/expenses.blade.php
@@ -38,7 +38,7 @@
     </form>
 
     <button type="button" id="btnOpenAddModal" class="btn btn-primary mb-5 d-block" data-bs-toggle="modal"
-        data-bs-target="#expenseModal">Ausgabe erstellen</button>
+        data-bs-target="#expenseModal" accesskey="a">Ausgabe erstellen</button>
 
     <div class="text-center mb-2">
         <p id="txtBalance" class="fw-bolder display-3 mb-0 {{ $balance < 0 ? 'text-danger' : 'text-success' }}">
@@ -191,12 +191,12 @@
                     </div>
 
                     <div class="modal-footer">
-                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal">
+                        <button id="btnDismissChanges" class="btn btn-danger" type="button" data-bs-dismiss="modal" accesskey="d">
                             Verwerfen
                         </button>
 
                         <button class="btn btn-primary"
-                            type="submit">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
+                            type="submit" accesskey="s">{{ session('shouldOpenModal') == 'edit' ? 'Bearbeiten' : 'Erstellen' }}
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
Einfache keyboard shortcuts hinzugefügt:

Ausgabe/Kategorie/Konto erstellen -> A
Erstellen/Speichern -> S
Verwerfen -> D

Firefox/Brave -> Alt + Shift + Key
Chrome -> Alt + Key